### PR TITLE
Fix compilation warnings seen with gcc14.

### DIFF
--- a/src/CondFolderMgr.cxx
+++ b/src/CondFolderMgr.cxx
@@ -316,7 +316,6 @@ CondFolderMgr::createCondDBFolder( const string& fullPathName,
     // It is really new; create new CondFolder
     string parentFolderSet;
     string folderName;
-    bool first=0;
     splitPath( fullPathName, parentFolderSet, folderName);
 
     // look for the parentFolderSet
@@ -336,7 +335,6 @@ CondFolderMgr::createCondDBFolder( const string& fullPathName,
 	else {  // create parentFolderSet with same attributes and description
 	    DebugMesg(CondDB, user, "Creating parent FolderSet");
 	    createCondDBFolderSet(parentFolderSet, attributes, description, true, 1);
-	    first=1;
 	}
 	res = relFolderMgr->find(parentFolderSet, MySqlFolderMgr::FolderSet);
     }

--- a/src/MySqlDBMgr.cxx
+++ b/src/MySqlDBMgr.cxx
@@ -185,8 +185,8 @@ void MySqlDBMgr::init(string& databaseInfo)
     if (sep == std::string::npos){
       password = databaseInfo;
       DebugMesg(CondDB, user, "passwd = " << password);
-      char *aux;
 #ifdef HAVE_STDLIB_H
+      char *aux;
       aux= getenv("CONDDB_PORT");
       // if there is no port defined we must use the default
       if (aux !=  NULL)
@@ -370,7 +370,7 @@ void MySqlDBMgr::getDBPath(int db_id, string& db_name, string& srv_name)
  * The datapath is identified the pair of integers folderId and databaseId.
  */
 
-void MySqlDBMgr::getFolderId(string folderName, int& folderId, int& databaseId)
+void MySqlDBMgr::getFolderId(string folderName, int& folderId, int& dbid)
 
 {
     MYSQLSTREAM query;
@@ -378,7 +378,7 @@ void MySqlDBMgr::getFolderId(string folderName, int& folderId, int& databaseId)
     MySqlResult *res = select(query);
     Assert ( res->countRows() != 0 );
     folderId = res->getIntField(0);
-    databaseId = res->getIntField(1);
+    dbid = res->getIntField(1);
     delete res;
 }
 

--- a/src/MySqlObjectMgr.cxx
+++ b/src/MySqlObjectMgr.cxx
@@ -573,8 +573,8 @@ void MySqlObjectMgr::addTag(int folderId, int newTagId, int oldTagId)
     }
     MySqlResult *res = select(query);
     // Now tag the objects
-    if ( res->countRows()!=0 )
-	//Deleting objects that are allready tagged. If we don't delete them they will be stored in
+    if ( res->countRows()!=0 ) {
+	//Deleting objects that are already tagged. If we don't delete them they will be stored in
 	//the tag2obk_tbl_# table again and again....
 	query << "DELETE FROM " TAG2OBJ_TBL_N << folderId << " WHERE tag_id = " << newTagId;
 	execute(query);
@@ -585,6 +585,7 @@ void MySqlObjectMgr::addTag(int folderId, int newTagId, int oldTagId)
 		  << newTagId << "," << res->getField(0) << "," << res->getCondDBKeyField(1) << "," << res->getCondDBKeyField(2) << ")";
 	    execute(query);
 	} while (res->nextRow());
+    }
 
     delete res;
 }

--- a/src/MySqlOnlineMgr.cxx
+++ b/src/MySqlOnlineMgr.cxx
@@ -791,7 +791,7 @@ void MySqlOnlineMgr::storeOnlId (int fldId, int partId, CondDBTable *table)
 	    Id = values[0];
 	} while ( blockId==Id && l<table->getNumRows());
 
-	SimpleTime tills, sinces;
+	SimpleTime sinces;
 	table->getSinceTime(l-1, sinces);
 	since=sinces;
 

--- a/src/MySqlTypes.h
+++ b/src/MySqlTypes.h
@@ -187,10 +187,10 @@ inline MySqlHandle::~MySqlHandle()
     if ( is_opened )
     {
 // CondDBLog
-      if (theLog->isUsable())
+      if (theLog->isUsable()) 
 	theLog->StoreLog("MySqlHandle:: Connection Successfully closed!");
 
-	mysql_close(&mysqlApp);
+      mysql_close(&mysqlApp);
     }
 }
 

--- a/src/SimpleTime.cxx
+++ b/src/SimpleTime.cxx
@@ -4,6 +4,7 @@
 #include "IntegerConversion.h"
 
 #include <time.h>
+#include <limits>
 
 #define DEBUG
 
@@ -21,8 +22,8 @@ const TimeT SIMPLETIME_BILLION     = 1000000000LL;              // #nanoseconds 
 const TimeT SIMPLETIME_UNIX_ORIGIN = 2208988800000000000LL;     // 1.1.1970
 const TimeT SIMPLETIME_UNIX_MAX    = 4356476047000000000LL;     // 19.01.2038
 //-ULL const TimeT SIMPLETIME_MAX         = 18446744073709551615LL;    // 2^64-1 ("infinity"), 02.07.2484
-const TimeT SIMPLETIME_MIN         = -9223372036854775808LL;    // -2^63
-const TimeT SIMPLETIME_MAX         = 9223372036854775807LL;     // 2^63-1 ("infinity"), sometime in 2262
+const TimeT SIMPLETIME_MIN         = std::numeric_limits<TimeT>::min();    // -2^63
+const TimeT SIMPLETIME_MAX         = std::numeric_limits<TimeT>::max();     // 2^63-1 ("infinity"), sometime in 2262
 #endif
 
 

--- a/tests/storeDataOnChange/cdbStore.h
+++ b/tests/storeDataOnChange/cdbStore.h
@@ -38,7 +38,7 @@ extern "C" {
 #include<stdio.h>
 #include<stdlib.h>
 #include<time.h>
-};
+}
 #include <iostream>
 
 

--- a/tests/storeDataOnChange/storeDataOnChange.cxx
+++ b/tests/storeDataOnChange/storeDataOnChange.cxx
@@ -147,13 +147,13 @@ int main(){
 
 	//Get's the actual time in order to change the sinceTime
 	time (&tnow);
-	SimpleTime since (tnow);
+	SimpleTime since2 (tnow);
 
 	//Changes the sinceTime
 	//Note: when we create a table the setSinceTime function is used. 
 	//When we want to do an update we use the changeSinceTime function
 	//providing also the number of the row - in this case equal to the number of the ID
-	tableId->changeSinceTime(nextId, since);
+	tableId->changeSinceTime(nextId, since2);
 
 	//Storing the data in the database
 	myData->store(folder, tableId);


### PR DESCRIPTION
- Misleading indentation.
- Unused variables.
- Use numeric_limits rather than hardcoding limits for int64_t.  Fixes in passing a warning that a constant is too large to be represented as a signed integer.
- Member function parameter shadowing a data member, and variable shadowing variable in outer scope.
- Extraneous trailing semicolon.



BEGINRELEASENOTES
- Fix a number of compilation warnings seen with recent compiler versions.
ENDRELEASENOTES