### PR TITLE
Convert latin1 encodings to utf-8.

### DIFF
--- a/include/ConditionsDB/SimpleTime.h
+++ b/include/ConditionsDB/SimpleTime.h
@@ -40,7 +40,7 @@
 //
 // __References__
 // Number of days per year (365.25637):
-// - Nordling, Österman:
+// - Nordling, Ã–sterman:
 //   Physics Handbook For Science And Engineering,
 //   Studentlitteratur AB, 1999. ISBN 9144008236
 // For time_t:

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -39,8 +39,8 @@
 
 
 //
-// Modifica o código para usar a consola para debug ou, preferencialmente,
-// a função mysql_debug().
+// Modifica o cÃ³digo para usar a consola para debug ou, preferencialmente,
+// a funÃ§Ã£o mysql_debug().
 //
 
 #ifndef Debug_h

--- a/tests/performanceTests/performanceTests.cxx
+++ b/tests/performanceTests/performanceTests.cxx
@@ -845,7 +845,7 @@ int main ()
 
     //Tests to the BLOB interface:
     long n_obj[5]={10,100,1000,10000,50000};
-    int num_tests = 5;           //Nº of tests to perform = number of values in the array n_obj
+    int num_tests = 5;           //NÂº of tests to perform = number of values in the array n_obj
 
     //Tests to the CondDBTable interface:
     int numOfColumns[8] = {1,2,3,4,5,6,7,8};              //Array to the maximum number of columns


### PR DESCRIPTION
Avoids warnings from clang.


BEGINRELEASENOTES
- Fixed some clang warnings by converting from latin1 encodings to utf8.
ENDRELEASENOTES