### PR TITLE
Fix clang warnings.

### DIFF
--- a/src/IntegerConversion.h
+++ b/src/IntegerConversion.h
@@ -13,14 +13,6 @@
 #include <iostream> 
 #include <string> 
 
-// Prevents the compiler from generating several copies of 
-// methods during the precompiling stage, which leads to longer 
-// compile time. 
-
-#if defined(__GNUC__) 
-#pragma interface 
-#endif
-
 template <class Integer> class IntegerConversion {
 
 public:
@@ -50,10 +42,6 @@ private:
   // for conversion from string to integer. 
   Integer rec_strtoi(const AIDA_STD::string &s); 
 };
-
-#if defined(__GNUC__) 
-#pragma implementation 
-#endif
 
 template <class Integer> AIDA_STD::string IntegerConversion<Integer>:: itostr(Integer n) {
 

--- a/src/MySqlDBMgr.cxx
+++ b/src/MySqlDBMgr.cxx
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 1999-2003 FreeDevices.org  geral@freedevices.org
+ Copyright (C) 1999-2003, 2025 FreeDevices.org  geral@freedevices.org
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -152,7 +152,7 @@ void MySqlDBMgr::init(string& databaseInfo)
 
     DebugMesg(CondDB, user, "databaseInfo = " << databaseInfo);
 
-    unsigned int sep = databaseInfo.find_first_of(":");
+    std::string::size_type sep = databaseInfo.find_first_of(":");
     int end = databaseInfo.size();
     serverName = databaseInfo.substr(0, sep);
     databaseInfo = databaseInfo.substr(sep + 1, end);

--- a/src/MySqlDBMgr.h
+++ b/src/MySqlDBMgr.h
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 1999-2003 FreeDevices.org  geral@freedevices.org
+ Copyright (C) 1999-2003, 2025 FreeDevices.org  geral@freedevices.org
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -61,9 +61,9 @@ class MySqlDBMgr : public MySqlConnection {
     void startRead();
 
     // Get the time maintained by the DBMS, which should be used for timestamps
-    string getDBName() { return databaseName; }
+    const string& getDBName() { return databaseName; }
 
-    string getSrvName() { return serverName; }
+    const string& getSrvName() { return serverName; }
 
     // The connect() method which establishes the DBMS connection
     // Defined in the superclass

--- a/src/MySqlOnlineMgr.cxx
+++ b/src/MySqlOnlineMgr.cxx
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 1999-2003 FreeDevices.org  geral@freedevices.org
+ Copyright (C) 1999-2003, 2025 FreeDevices.org  geral@freedevices.org
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -1097,7 +1097,7 @@ void MySqlOnlineMgr::getSchema(int fldId, int partId, CondDBTable *table, bool v
 	string fname = res->getField(0);
 	string type = res->getField(1);
 	string name;
-	CondDBTable::cdb_types colType;
+	CondDBTable::cdb_types colType = CondDBTable::cdbNull;
 	if (type!="blob")
 	{
 	    if (type=="float") colType=CondDBTable::cdbFloat;

--- a/src/SimpleTimeDuration.cxx
+++ b/src/SimpleTimeDuration.cxx
@@ -141,7 +141,7 @@ void SimpleTimeDuration::operator *= (const double & factor) {
   }
   if (isPlusInf()) { // Leave unchanged if infinity
     return;
-  } else if (SIMPLEDURATION_MAX/factor < (double)durationval) { // Overflow!
+  } else if (static_cast<double>(SIMPLEDURATION_MAX)/factor < (double)durationval) { // Overflow!
     setPlusInf();
   } else { // Normal case
     durationval = (DurationT) ceil(durationval*factor);
@@ -155,7 +155,7 @@ void SimpleTimeDuration::operator /= (const double & denom) {
   }
   if (isPlusInf()) { // Leave unchanged if infinity
     return;
-  } else if ((denom < 1) && (durationval > denom*SIMPLEDURATION_MAX)) {
+  } else if ((denom < 1) && (durationval > denom*static_cast<double>(SIMPLEDURATION_MAX))) {
     setPlusInf(); // Overflow! TODO: Throw an exception
   } else {
     durationval = (DurationT) ceil(durationval/denom);
@@ -183,7 +183,7 @@ SimpleTimeDuration operator / (const SimpleTimeDuration & d,
 double operator / (const SimpleTimeDuration & d,
 		   const SimpleTimeDuration & denom) {
   if (d.isPlusInf()) {
-    return SIMPLEDURATION_MAX;
+    return static_cast<double>(SIMPLEDURATION_MAX);
   } else if (denom.isPlusInf()) {
     return .0;
   } else {


### PR DESCRIPTION
 - Remove obsolete interface/implementation pragmas.
 - Wrong type for std::string indices.
 - Fix use of pointers to dangling temporaries.
 - Possible use of uninitialized variable.
 - Avoid warnings about precision loss in int64->double conversion.

BEGINRELEASENOTES
- Fix a number of compilation warnings seen with clang.
ENDRELEASENOTES