### PR TITLE
Update minimum cmake version to 3.10.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #################################################################
 # CMakeLists to build CondDBMySQL
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 #################################################################
 
 


### PR DESCRIPTION
Get rid of cmake deprecation warning.

BEGINRELEASENOTES
- Updated minimum cmake version to 3.10 to remove deprecation warnings.
ENDRELEASENOTES